### PR TITLE
Add AutoSave Example - React

### DIFF
--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -16,7 +16,8 @@
     "defaultWindowStyle": {
       "width": 900,
       "height": 420
-    }
+    },
+    "autosave": true
   },
   "dataServices": [
     {

--- a/webClient/src/App.tsx
+++ b/webClient/src/App.tsx
@@ -16,6 +16,8 @@ import { withTranslation } from 'react-i18next';
 class App extends React.Component<any, any> {
   private log: ZLUX.ComponentLogger;
   t: any;
+  sessionEvents:any;
+  autoSaveEvent:any;
   constructor(props){
     super(props);
     this.log = this.props.resources.logger;
@@ -25,6 +27,12 @@ class App extends React.Component<any, any> {
     } else {
       this.state = this.getDefaultState();
     }
+    this.sessionEvents = this.props.resources.sessionEvents;
+    this.autoSaveEvent = this.sessionEvents.autosaveEmitter.subscribe((saveThis: any)=> {
+      if (saveThis) {
+        saveThis({'appData':{'requestText':this.state.parameters,'targetAppId':this.state.appId}});
+      }
+    });
 
   };
 
@@ -73,8 +81,8 @@ class App extends React.Component<any, any> {
         if (mode == 'PluginCreate' || mode == 'PluginFindAnyOrCreate') {
           this.updateOrInitState({actionType: actionType,
                                   appTarget: mode,
-                                  appId: data.targetAppId,
-                                  parameters: data.requestText});
+                                  appId: data.appData.targetAppId,
+                                  parameters: data.appData.requestText});
         } else {
           msg = `Invalid target mode given (${mode})`;
           this.log.warn(msg);
@@ -336,6 +344,10 @@ class App extends React.Component<any, any> {
         </MemoryRouter>
     );
   }
+
+  componentWillUnmount(){
+    this.autoSaveEvent.unsubscribe();
+ }
 }
 
 export default withTranslation('translation')(App);


### PR DESCRIPTION
This PR serves as an example of how to subscribe to an AutoSave Event by Zowe Desktop for a React Application

This example demonstrates how to save the `parameters` and `AppId` of React App: 

**1. Retrieve the sessionEvents from the resources props**
` this.sessionEvents = this.props.resources.sessionEvents;`

**2. Subscribe to autosaveEmitter**
```
    this.autoSaveEvent = this.sessionEvents.autosaveEmitter.subscribe((saveThis: any)=> {
      if (saveThis) {
        saveThis({'appData':{'requestText':this.state.parameters,'targetAppId':this.state.appId}});
      }
    });
```

**3. Receive saved data**
In order to receive the data, use `data.appData.requestText` and `data.appData.targetAppId` as seen in `handleLaunchOrMessageObject()` 

**Note:**
1. _It is necessary to unsubscribe to the AutoSave Event when the component unmounts_
2. _You must add an autosave property to pluginDefinition `"autosave": true`_


Signed-off-by: miteshgoplani miteshgoplani@gmail.com