### PR TITLE
update workflow actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: '[Prep 2] Cache node modules'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -137,7 +137,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-cache-node-modules-
       - name: '[Prep 3] Setup Node'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16.15.0
 


### PR DESCRIPTION
The Github actions are automatically failing because it uses a deprecated version of both  `actions/cache@v2` `actions/setup-node@v2`. I have upgraded both to version 4. 
